### PR TITLE
Navigation Cleanup and Route Audit

### DIFF
--- a/missing_pages_report.md
+++ b/missing_pages_report.md
@@ -1,0 +1,28 @@
+# Missing Pages Report
+
+Based on the analysis of the application routing (`src/main-home.tsx`) and the navigation menu (`src/components/layout/Header.tsx`), the following pages are currently active in the routing but are **not listed** in the main navigation bar or its dropdowns:
+
+## 1. Blog
+- **Route:** `/blog`
+- **Component:** `BlogPage`
+- **Status:** Fully functional page but completely missing from the navigation.
+
+## 2. Mandatory Disclosure
+- **Route:** `/mandatory-disclosure`
+- **Component:** `MandatoryDisclosurePage`
+- **Status:** Missing from the Header navigation (currently only accessible via the Footer).
+
+## 3. Login
+- **Route:** `/login`
+- **Component:** `LoginPage`
+- **Status:** There is no explicit "Login" link in the header for guest users, although there is logic to show user status once logged in.
+
+## 4. Development Page (Excluded per request)
+- **Route:** `/development`
+- **Component:** `DevelopmentPage`
+
+## Note on Admin/Broken Routes
+- The route `/admin/gallery` points to a non-existent component (`src/pages/admin/GalleryAdmin`), causing build errors. This page is effectively missing/broken.
+
+## Recommendation
+Consider adding "Mandatory Disclosure" to the "About" dropdown or the Utility Bar (top right), and "Blog" to the "Student Life" or a new "News & Blog" section if desired.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -20,10 +20,6 @@ const navItems: NavItem[] = [
     label: 'About',
     href: '/about',
     subItems: [
-      { label: 'Principal\'s Message', href: '/about#principal' },
-      { label: 'School History', href: '/about#history' },
-      { label: 'Vision & Mission', href: '/about#vision' },
-      { label: 'Administration', href: '/about#admin' },
       { label: 'Facilities', href: '/facilities' }
     ]
   },
@@ -31,31 +27,16 @@ const navItems: NavItem[] = [
     label: 'Academics',
     href: '/academics',
     subItems: [
-      { label: 'Curriculum', href: '/academics#curriculum' },
-      { label: 'Departments', href: '/academics#departments' },
-      { label: 'Academic Calendar', href: '/calendar' },
-      { label: 'Scholars', href: '/academics' }
+      { label: 'Academic Calendar', href: '/calendar' }
     ]
   },
   {
     label: 'Admissions',
-    href: '/admissions',
-    subItems: [
-      { label: 'Admission Procedure', href: '/admissions#procedure' },
-      { label: 'Fee Structure', href: '/admissions#fees' },
-      { label: 'Transfer Certificates', href: '/admissions#tc' },
-      { label: 'FAQs', href: '/admissions#faqs' }
-    ]
+    href: '/admissions'
   },
   {
     label: 'Student Life',
-    href: '/student-life',
-    subItems: [
-      { label: 'Houses', href: '/student-life#houses' },
-      { label: 'Clubs & Societies', href: '/student-life#clubs' },
-      { label: 'Sports', href: '/student-life#sports' },
-      { label: 'NCC', href: '/student-life#ncc' }
-    ]
+    href: '/student-life'
   },
   {
     label: 'Achievements',

--- a/src/main-home.tsx
+++ b/src/main-home.tsx
@@ -24,7 +24,7 @@ const NewsPage = lazy(() => import('./pages/content/NewsPage'));
 const NoticesPage = lazy(() => import('./pages/content/NoticesPage'));
 const LoginPage = lazy(() => import('./pages/utility/LoginPage'));
 const SearchPage = lazy(() => import('./pages/utility/SearchPage'));
-const GalleryAdmin = lazy(() => import('./pages/admin/GalleryAdmin'));
+// const GalleryAdmin = lazy(() => import('./pages/admin/GalleryAdmin'));
 const DevelopmentPage = lazy(() => import('./pages/utility/DevelopmentPage'));
 
 import { GoogleOAuthProvider } from '@react-oauth/google';
@@ -73,7 +73,7 @@ root.render(
                         <Route path="/notices" element={<NoticesPage />} />
                         <Route path="/login" element={<LoginPage onLogin={() => { }} onBack={() => window.history.back()} />} />
                         <Route path="/search" element={<SearchPage />} />
-                        <Route path="/admin/gallery" element={<GalleryAdmin />} />
+                        {/* <Route path="/admin/gallery" element={<GalleryAdmin />} /> */}
                         <Route path="/development" element={<DevelopmentPage />} />
                     </Routes>
                 </Suspense>


### PR DESCRIPTION
This change addresses the request to clean up the navigation bar by removing "useless" dropdown options that merely pointed to internal section anchors. It also includes an audit of existing routes, identifying pages not currently linked in the navigation, provided in `missing_pages_report.md`. Additionally, it fixes a build error caused by a missing component.

---
*PR created automatically by Jules for task [7242277212478641703](https://jules.google.com/task/7242277212478641703) started by @aryan-357*