### PR TITLE
feat: Enable TinaCMS Contextual Editing

### DIFF
--- a/src/components/TinaBlocksRenderer.tsx
+++ b/src/components/TinaBlocksRenderer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { tinaField } from "tinacms/dist/react";
 import ParallaxCarousel from './sections/parallax-carousel/ParallaxCarousel';
 import LatestNews from './sections/LatestNews';
 import NoticeBoard from './sections/NoticeBoard';
@@ -17,34 +18,34 @@ const TinaBlocksRenderer: React.FC<TinaBlocksRendererProps> = ({ blocks }) => {
     <>
       {blocks.map((block, i) => {
         // Handle both GraphQL __typename and manual _template (if strictly used in dev without GraphQL)
-        // Expected __typename format: PageFlexible_pageBlocks<BlockTemplateName>
-
         let templateName = '';
         if (block.__typename) {
              templateName = block.__typename;
         } else if (block._template) {
-             // Fallback for manual _template, though we should prefer __typename
-             // If manual, we construct what we expect the switch case to be, or handle it directly
-             // For simplicity, let's map _template to the expected typename format if possible,
-             // or just let the switch handle the raw _template if we added cases for it.
-             // But actually, let's just use the _template name capitalized as a suffix check if we wanted to be generic.
-             // For now, let's stick to the generated typenames we saw in the error.
              templateName = `PageFlexible_pageBlocks${block._template.charAt(0).toUpperCase() + block._template.slice(1)}`;
         }
 
+        let Component = null;
+
         switch (templateName) {
           case 'PageFlexible_pageBlocksHeroCarousel':
-            return <ParallaxCarousel key={i} {...block} />;
+            Component = ParallaxCarousel;
+            break;
           case 'PageFlexible_pageBlocksLatestNews':
-            return <LatestNews key={i} {...block} />;
+            Component = LatestNews;
+            break;
           case 'PageFlexible_pageBlocksNoticeBoard':
-            return <NoticeBoard key={i} {...block} />;
+            Component = NoticeBoard;
+            break;
           case 'PageFlexible_pageBlocksTopperSection':
-            return <TopperSection key={i} {...block} />;
+            Component = TopperSection;
+            break;
           case 'PageFlexible_pageBlocksPhilosophySection':
-            return <PhilosophySection key={i} {...block} />;
+            Component = PhilosophySection;
+            break;
           case 'PageFlexible_pageBlocksCampusLifeSection':
-            return <CampusLifeSection key={i} {...block} />;
+            Component = CampusLifeSection;
+            break;
           default:
             console.warn(`Unrecognized block type: ${templateName}`, block);
             return (
@@ -54,6 +55,14 @@ const TinaBlocksRenderer: React.FC<TinaBlocksRendererProps> = ({ blocks }) => {
               </div>
             );
         }
+
+        // We wrap the block to enable "Click to Edit" (Contextual Editing) for the block itself.
+        // We also pass the 'block' object down so components can implement field-level editing.
+        return (
+          <div key={i} data-tina-field={tinaField(block)}>
+            <Component {...block} block={block} />
+          </div>
+        );
       })}
     </>
   );

--- a/src/components/sections/CampusLifeSection.tsx
+++ b/src/components/sections/CampusLifeSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
+import { tinaField } from "tinacms/dist/react";
 
 interface CampusLifeSectionProps {
     title?: string;
@@ -9,6 +10,7 @@ interface CampusLifeSectionProps {
     linkText?: string;
     linkUrl?: string;
     images?: string[];
+    block?: any;
 }
 
 const CampusLifeSection: React.FC<CampusLifeSectionProps> = ({
@@ -17,7 +19,8 @@ const CampusLifeSection: React.FC<CampusLifeSectionProps> = ({
     description = 'Experience the vibrant atmosphere and state-of-the-art facilities at Air Force School Hindan.',
     linkText = 'Explore Gallery',
     linkUrl = '/gallery',
-    images
+    images,
+    block
 }) => {
     const displayImages = images || [1, 2, 3, 4].map(i => `https://picsum.photos/seed/campus${i}/600/800`);
 
@@ -36,12 +39,28 @@ const CampusLifeSection: React.FC<CampusLifeSectionProps> = ({
             <div className="container mx-auto px-4 relative z-10">
                 <div className="flex flex-col md:flex-row justify-between items-end mb-12 gap-6">
                     <div>
-                        <span className="text-af-light font-bold tracking-widest text-xs uppercase mb-2 block">{subtitle}</span>
-                        <h2 className="text-4xl md:text-5xl font-serif font-bold">{title}</h2>
-                        <p className="text-gray-500 mt-4 max-w-xl text-lg">{description}</p>
+                        <span
+                            data-tina-field={block ? tinaField(block, 'subtitle') : undefined}
+                            className="text-af-light font-bold tracking-widest text-xs uppercase mb-2 block"
+                        >
+                            {subtitle}
+                        </span>
+                        <h2
+                            data-tina-field={block ? tinaField(block, 'title') : undefined}
+                            className="text-4xl md:text-5xl font-serif font-bold"
+                        >
+                            {title}
+                        </h2>
+                        <p
+                            data-tina-field={block ? tinaField(block, 'description') : undefined}
+                            className="text-gray-500 mt-4 max-w-xl text-lg"
+                        >
+                            {description}
+                        </p>
                     </div>
                     <Link
                         to={linkUrl}
+                        data-tina-field={block ? tinaField(block, 'linkText') : undefined}
                         className="hidden md:flex items-center gap-2 bg-white text-black px-8 py-4 hover:bg-af-blue hover:text-white transition duration-300 uppercase text-xs font-bold tracking-widest rounded-full shadow-xl"
                     >
                         {linkText}

--- a/src/components/sections/LatestNews.tsx
+++ b/src/components/sections/LatestNews.tsx
@@ -5,13 +5,15 @@ import { ArrowUpRight } from 'lucide-react';
 import { BlogPost } from '../../types/blog';
 import { PostService } from '../../services/postService';
 import { getStrapiMedia, extractImageUrl } from '../../utils/strapi';
+import { tinaField } from "tinacms/dist/react";
 
 interface LatestNewsProps {
   title?: string;
   count?: number;
+  block?: any;
 }
 
-const LatestNews: React.FC<LatestNewsProps> = ({ title, count = 3 }) => {
+const LatestNews: React.FC<LatestNewsProps> = ({ title, count = 3, block }) => {
   const [posts, setPosts] = useState<BlogPost[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -54,7 +56,12 @@ const LatestNews: React.FC<LatestNewsProps> = ({ title, count = 3 }) => {
     <section className="group bg-white dark:bg-gray-950 transition-colors duration-500 overflow-hidden">
       {title && (
         <div className="container mx-auto px-6 py-8">
-          <h2 className="text-3xl md:text-4xl font-serif font-bold text-gray-900 dark:text-white mb-4">{title}</h2>
+          <h2
+            data-tina-field={block ? tinaField(block, 'title') : undefined}
+            className="text-3xl md:text-4xl font-serif font-bold text-gray-900 dark:text-white mb-4"
+          >
+            {title}
+          </h2>
         </div>
       )}
       <div className="w-full">

--- a/src/components/sections/NoticeBoard.tsx
+++ b/src/components/sections/NoticeBoard.tsx
@@ -4,12 +4,14 @@ import { Bell, Calendar, ChevronRight, ChevronDown, Download, FileText, Loader2 
 import { motion, AnimatePresence } from 'framer-motion';
 import { Notice } from '../../types/strapi';
 import { fetchRecentNotices } from '../../services/noticeService';
+import { tinaField } from "tinacms/dist/react";
 
 interface NoticeBoardProps {
   title?: string;
+  block?: any;
 }
 
-const NoticeBoard: React.FC<NoticeBoardProps> = ({ title = 'Notice Board' }) => {
+const NoticeBoard: React.FC<NoticeBoardProps> = ({ title = 'Notice Board', block }) => {
   const [notices, setNotices] = useState<Notice[]>([]);
   const [loading, setLoading] = useState(true);
   const [openNoticeId, setOpenNoticeId] = useState<number | null>(null);
@@ -79,7 +81,10 @@ const NoticeBoard: React.FC<NoticeBoardProps> = ({ title = 'Notice Board' }) => 
               className="lg:col-span-2 bg-white dark:bg-gray-900 rounded-3xl shadow-2xl border border-gray-100 dark:border-gray-800 overflow-hidden transition-all duration-300"
             >
               <div className="p-6 border-b border-gray-100 dark:border-gray-800 flex justify-between items-center bg-white dark:bg-gray-900">
-                <h3 className="text-2xl font-serif font-bold text-gray-900 dark:text-white flex items-center gap-3">
+                <h3
+                    data-tina-field={block ? tinaField(block, 'title') : undefined}
+                    className="text-2xl font-serif font-bold text-gray-900 dark:text-white flex items-center gap-3"
+                >
                   <div className="w-10 h-10 bg-af-blue/10 rounded-xl flex items-center justify-center">
                     <Bell className="text-af-blue" size={20} />
                   </div>

--- a/src/components/sections/PhilosophySection.tsx
+++ b/src/components/sections/PhilosophySection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
+import { tinaField } from "tinacms/dist/react";
 
 export interface PhilosophyItem {
     title: string;
@@ -11,6 +12,7 @@ interface PhilosophySectionProps {
     title?: string;
     subtitle?: string;
     items?: PhilosophyItem[];
+    block?: any; // TinaCMS block data for contextual editing
 }
 
 const defaultItems: PhilosophyItem[] = [
@@ -22,7 +24,8 @@ const defaultItems: PhilosophyItem[] = [
 const PhilosophySection: React.FC<PhilosophySectionProps> = ({
     title = 'Fostering Excellence, Integrity, and Service',
     subtitle = 'Our Philosophy',
-    items = defaultItems
+    items = defaultItems,
+    block
 }) => {
     return (
         <motion.section
@@ -34,8 +37,16 @@ const PhilosophySection: React.FC<PhilosophySectionProps> = ({
             transition={{ duration: 0.6, ease: "easeOut" }}
         >
             <div className="container mx-auto px-4 text-center">
-                <span className="text-af-blue dark:text-af-light font-bold tracking-[0.3em] text-xs uppercase mb-4 block">{subtitle}</span>
-                <h2 className="text-3xl md:text-5xl font-serif font-bold text-gray-900 dark:text-white mb-10 max-w-3xl mx-auto leading-tight">
+                <span
+                    data-tina-field={block ? tinaField(block, 'subtitle') : undefined}
+                    className="text-af-blue dark:text-af-light font-bold tracking-[0.3em] text-xs uppercase mb-4 block"
+                >
+                    {subtitle}
+                </span>
+                <h2
+                    data-tina-field={block ? tinaField(block, 'title') : undefined}
+                    className="text-3xl md:text-5xl font-serif font-bold text-gray-900 dark:text-white mb-10 max-w-3xl mx-auto leading-tight"
+                >
                     {title}
                 </h2>
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-10 mt-12">
@@ -43,6 +54,13 @@ const PhilosophySection: React.FC<PhilosophySectionProps> = ({
                         <motion.div
                             key={idx}
                             whileHover={{ y: -10 }}
+                            data-tina-field={block ? tinaField(block.items[idx], 'title') : undefined}
+                            // Note: field selection for array items requires passing the specific item object if we want to deep select,
+                            // but usually tinaField(block, `items.${idx}`) is complex.
+                            // Better to just let them click the main block or use the array UI in sidebar.
+                            // But if block.items exists and corresponds to this, we can try.
+                            // However, block.items in the prop might be the simple array. The 'block' prop has the metadata.
+                            // Let's stick to title/subtitle for now to avoid errors if structure differs.
                             className="p-8 rounded-2xl bg-gray-50 dark:bg-gray-800/50 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-700 hover:shadow-2xl transition duration-500 border border-gray-100 dark:border-gray-700 group shadow-lg"
                         >
                             <div className="text-5xl mb-6 group-hover:scale-110 transition duration-500 inline-block">{item.icon}</div>


### PR DESCRIPTION
Enable contextual editing (visual editing) for TinaCMS by:
1. Updating `TinaBlocksRenderer` to wrap blocks with `data-tina-field` and pass the `block` data to child components.
2. Updating `CampusLifeSection`, `LatestNews`, `NoticeBoard`, and `PhilosophySection` to accept the `block` prop and apply `data-tina-field` attributes to specific fields (title, subtitle, etc.).

---
*PR created automatically by Jules for task [14731919890709640623](https://jules.google.com/task/14731919890709640623) started by @aryan-357*