### PR TITLE
Add /strapi redirect route

### DIFF
--- a/src/main-home.tsx
+++ b/src/main-home.tsx
@@ -72,6 +72,9 @@ root.render(
                     {/* Status Redirect - Outside Layout */}
                     <Route path="/status" element={<ExternalRedirect to="https://dashboard.uptimerobot.com/monitors" />} />
 
+                    {/* Strapi Redirect - Outside Layout */}
+                    <Route path="/strapi" element={<ExternalRedirect to="https://afsh-backend-blog-production.up.railway.app/" />} />
+
                     {/* All other routes wrapped in Layout */}
                     <Route path="*" element={
                         <Layout>


### PR DESCRIPTION
This PR adds a `/strapi` route to the application. When accessed, this route will redirect the user to `https://afsh-backend-blog-production.up.railway.app/`. This implementation uses the existing `ExternalRedirect` component in `src/main-home.tsx` and places the route alongside the existing `/status` redirect, ensuring it bypasses the main layout. Use of `ExternalRedirect` ensures consistent behavior for external links. Verified by successful build.

---
*PR created automatically by Jules for task [15006568687973181183](https://jules.google.com/task/15006568687973181183) started by @aryan-357*