### PR TITLE
Add Cloudflare Web Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
 <body>
   <div id="root"></div>
   <script type="module" src="/src/main-home.tsx"></script>
+  <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "0d26da01b93845eb99c60f9c51706ff3"}'></script><!-- End Cloudflare Web Analytics -->
 </body>
 
 </html>


### PR DESCRIPTION
Added the Cloudflare Web Analytics snippet to `index.html` as requested. The script is loaded with `defer` and placed just before the closing `</body>` tag to ensure it doesn't block rendering. Verified that `npm run build` completes successfully.

---
*PR created automatically by Jules for task [1664009473197611687](https://jules.google.com/task/1664009473197611687) started by @aryan-357*