### PR TITLE
Identify missing VITE_ALUMNI_API_URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "air-force-school-hindan-clone",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@react-oauth/google": "^0.13.4",
         "@react-spring/web": "^10.0.3",


### PR DESCRIPTION
Identified that VITE_ALUMNI_API_URL is missing from the image by cross referencing environment variables used in the codebase.

---
*PR created automatically by Jules for task [7457768615937988991](https://jules.google.com/task/7457768615937988991) started by @aryan-357*