### PR TITLE
Fix Notices visibility issue by using centralized API client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "air-force-school-hindan-clone",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@react-oauth/google": "^0.13.4",
         "@react-spring/web": "^10.0.3",

--- a/src/services/noticeService.ts
+++ b/src/services/noticeService.ts
@@ -1,19 +1,13 @@
+import { apiClient } from '../api/client';
 import { StrapiResponse, Notice } from '../types/strapi';
-
-const STRAPI_URL = import.meta.env.VITE_STRAPI_URL || 'http://localhost:1337'; // Fallback or use env
 
 export const fetchNotices = async (page = 1, pageSize = 25): Promise<StrapiResponse<Notice[]>> => {
   try {
-    const response = await fetch(
-      `${STRAPI_URL}/api/notices?populate=file&sort=date:desc&pagination[page]=${page}&pagination[pageSize]=${pageSize}`
+    const response = await apiClient.get<StrapiResponse<Notice[]>>(
+      `/api/notices?populate=file&sort=date:desc&pagination[page]=${page}&pagination[pageSize]=${pageSize}`
     );
 
-    if (!response.ok) {
-      throw new Error(`Error fetching notices: ${response.statusText}`);
-    }
-
-    const data = await response.json();
-    return data;
+    return response.data;
   } catch (error) {
     console.error('Failed to fetch notices:', error);
     throw error;


### PR DESCRIPTION
The "Notices" page was empty on the deployment because the noticeService.ts was using a manual fetch call with a local fallback, which likely failed in the production environment. By switching to the centralized Axios apiClient, the service now inherits the correct production base URL and headers, aligning it with the working News section.

---
*PR created automatically by Jules for task [3814762554536158303](https://jules.google.com/task/3814762554536158303) started by @aryan-357*