### PR TITLE
fix: remove insecure HTTP fallback URL in production

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const STRAPI_URL = import.meta.env.VITE_STRAPI_URL || 'http://localhost:1337';
+const STRAPI_URL = import.meta.env.VITE_STRAPI_URL || (import.meta.env.DEV ? 'http://localhost:1337' : '');
 
 export const apiClient = axios.create({
     baseURL: STRAPI_URL,

--- a/src/services/noticeService.ts
+++ b/src/services/noticeService.ts
@@ -1,6 +1,6 @@
 import { StrapiResponse, Notice } from '../types/strapi';
 
-const STRAPI_URL = import.meta.env.VITE_STRAPI_URL || 'http://localhost:1337'; // Fallback or use env
+const STRAPI_URL = import.meta.env.VITE_STRAPI_URL || (import.meta.env.DEV ? 'http://localhost:1337' : ''); // Fallback or use env
 
 export const fetchNotices = async (page = 1, pageSize = 25): Promise<StrapiResponse<Notice[]>> => {
   try {

--- a/src/utils/strapi.ts
+++ b/src/utils/strapi.ts
@@ -1,5 +1,5 @@
 export const getStrapiURL = (path = '') => {
-    const baseURL = import.meta.env.VITE_STRAPI_URL || 'http://localhost:1337';
+    const baseURL = import.meta.env.VITE_STRAPI_URL || (import.meta.env.DEV ? 'http://localhost:1337' : '');
     // Remove trailing slash from base and leading slash from path to avoid double slashes
     const cleanBase = baseURL.replace(/\/$/, '');
     const cleanPath = path.replace(/^\//, '');


### PR DESCRIPTION
Removes hardcoded 'http://localhost:1337' fallback URLs in production environments to prevent insecure data transmission and mixed content warnings. These fallbacks are now conditionally applied only in development mode.