### PR TITLE
Fix gallery image metadata mismatch in lightbox

### DIFF
--- a/src/pages/content/GalleryPage.tsx
+++ b/src/pages/content/GalleryPage.tsx
@@ -260,18 +260,18 @@ const GalleryPage = () => {
     setCurrentPage(1);
   };
 
-  const photosForAlbum = paginatedPhotos.map(p => ({
+  const photosForAlbum = useMemo(() => paginatedPhotos.map(p => ({
     src: p.src,
     width: p.width,
     height: p.height,
     title: p.title
-  }));
+  })), [paginatedPhotos]);
 
-  const slides = filteredPhotos.map(p => ({
+  const slides = useMemo(() => filteredPhotos.map(p => ({
     src: p.src,
     title: p.title,
     description: `Taken on ${p.date} • ${p.album}`
-  }));
+  })), [filteredPhotos]);
 
   return (
     <PageAnimate className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white pb-12 transition-colors duration-300">
@@ -484,25 +484,29 @@ const GalleryPage = () => {
           ],
         }}
         on={{
-          view: () => setShowInfo(false),
+          view: ({ index: newIndex }) => {
+            setIndex(newIndex);
+            setShowInfo(false);
+          },
           click: () => {
             zoomRef.current?.zoomIn();
           },
         }}
         render={{
           buttonZoom: () => null,
-          slideFooter: ({ slide }) => {
-            if (!slide) return null;
-            return (
-              <animated.div
-                style={infoSpring}
-                className={`fixed bottom-6 left-0 right-0 mx-auto w-[90vw] max-w-[500px] bg-black/80 backdrop-blur-md p-5 rounded-2xl text-white shadow-2xl z-50 border border-white/10 transition-all ${showInfo ? 'pointer-events-auto' : 'pointer-events-none'}`}
-              >
-                <h3 className="font-bold text-lg mb-2 text-center">{slide.title}</h3>
-                <p className="text-sm text-gray-300 text-center">{slide.description}</p>
-              </animated.div>
-            );
-          },
+          controls: () => (
+            <animated.div
+              style={infoSpring}
+              className={`fixed bottom-10 left-1/2 -translate-x-1/2 w-[90vw] max-w-[500px] bg-black/80 backdrop-blur-md p-5 rounded-2xl text-white shadow-2xl z-[1000] border border-white/10 transition-all ${showInfo ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+            >
+              {index >= 0 && slides[index] && (
+                <>
+                  <h3 className="font-bold text-lg mb-2 text-center">{slides[index].title}</h3>
+                  <p className="text-sm text-gray-300 text-center">{slides[index].description}</p>
+                </>
+              )}
+            </animated.div>
+          ),
         }}
       />
 


### PR DESCRIPTION
The Gallery lightbox previously displayed incorrect metadata (title/description) for images because the `yet-another-react-lightbox` library renders and caches multiple `slideFooter` elements simultaneously. Since these footers used fixed positioning, they would often overlap, showing information from a preloaded slide instead of the one being viewed.

This PR refactors `src/components/Gallery.tsx` to:
1. Use `useMemo` for the `slides` data to ensure stable references.
2. Track the active slide index locally via the `on.view` callback.
3. Move the metadata panel to the global `render.controls` overlay, ensuring only the info for the currently active index is rendered.

Verified via Playwright by capturing screenshots of multiple slides and confirming the text matches the specific image data.

---
*PR created automatically by Jules for task [13984632802393898987](https://jules.google.com/task/13984632802393898987) started by @aryan-357*