### PR TITLE
🛰️ Spark: React 19 forwardRef removal - Simplify ref passing

### DIFF
--- a/.jules/spark.md
+++ b/.jules/spark.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - [React 19: Goodbye forwardRef]
+Learning: React 19 allows passing `ref` as a regular prop to functional components, making `forwardRef` obsolete and simplifying component definitions.
+Action: Removed `forwardRef` usage in `src/components/ui/Silk.tsx`, passing `ref` directly to `SilkPlane`. This reduces boilerplate and aligns the codebase with modern React patterns.

--- a/src/components/ui/Silk.tsx
+++ b/src/components/ui/Silk.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unknown-property */
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
-import React, { forwardRef, useRef, useMemo, useLayoutEffect, useEffect } from 'react';
+import React, { useRef, useMemo, useLayoutEffect, useEffect } from 'react';
 import { Color, Mesh } from 'three';
 
 interface SilkProps {
@@ -13,6 +13,7 @@ interface SilkProps {
 }
 
 interface SilkPlaneProps {
+    ref?: React.Ref<Mesh>;
     uniforms: {
         uSpeed: { value: number };
         uScale: { value: number };
@@ -89,7 +90,8 @@ void main() {
 }
 `;
 
-const SilkPlane = forwardRef<Mesh, SilkPlaneProps>(function SilkPlane({ uniforms }, ref) {
+// 🛰️ Spark: Removed forwardRef. In React 19, ref can be passed as a regular prop to functional components.
+function SilkPlane({ uniforms, ref }: SilkPlaneProps) {
     const { viewport } = useThree();
 
     useLayoutEffect(() => {
@@ -111,8 +113,7 @@ const SilkPlane = forwardRef<Mesh, SilkPlaneProps>(function SilkPlane({ uniforms
             <shaderMaterial uniforms={uniforms} vertexShader={vertexShader} fragmentShader={fragmentShader} />
         </mesh>
     );
-});
-SilkPlane.displayName = 'SilkPlane';
+}
 
 const Silk: React.FC<SilkProps> = ({
     speed = 5,


### PR DESCRIPTION
📺 Source: https://www.youtube.com/watch?v=0h95JzG5YjE (Fireship React 19 in 100 Seconds / New Features)

💡 What's New: React 19 eliminated the need for the `forwardRef` wrapper. Functional components can now accept `ref` as a standard property in their `props` object, drastically simplifying component definitions and type safety.

🎯 Application: Removed `forwardRef` from the `SilkPlane` component in `src/components/ui/Silk.tsx`. The `SilkPlaneProps` interface was explicitly typed with `ref?: React.Ref<Mesh>` to safely accept the standard prop. This strips away unnecessary wrapper boilerplate while maintaining compatibility with the existing React 19 environment and `@react-three/fiber` usage.

✅ Verification: The component types resolve correctly and `npm run build` passes locally. All temporary scripts were cleaned up to prevent repo pollution. Added documentation to `.jules/spark.md`.

---
*PR created automatically by Jules for task [6307513106752327501](https://jules.google.com/task/6307513106752327501) started by @aryan-357*