### PR TITLE
🛡️ Sentinel: Harden public forms with maxLength constraints

### DIFF
--- a/src/pages/core/ContactPage.tsx
+++ b/src/pages/core/ContactPage.tsx
@@ -268,6 +268,7 @@ const ContactPage: React.FC = () => {
                     value={formData.name}
                     onChange={handleChange}
                     required
+                    maxLength={100}
                     placeholder="Your full name"
                     className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-af-blue transition-all duration-300"
                   />
@@ -282,6 +283,7 @@ const ContactPage: React.FC = () => {
                       value={formData.email}
                       onChange={handleChange}
                       required
+                      maxLength={100}
                       placeholder="your@email.com"
                       className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-af-blue transition-all duration-300"
                     />
@@ -293,6 +295,7 @@ const ContactPage: React.FC = () => {
                       name="phone"
                       value={formData.phone}
                       onChange={handleChange}
+                      maxLength={100}
                       placeholder="+91 XXXXXXXXXX"
                       className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-af-blue transition-all duration-300"
                     />
@@ -307,6 +310,7 @@ const ContactPage: React.FC = () => {
                     value={formData.subject}
                     onChange={handleChange}
                     required
+                    maxLength={100}
                     placeholder="What is this about?"
                     className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-af-blue transition-all duration-300"
                   />
@@ -319,6 +323,7 @@ const ContactPage: React.FC = () => {
                     value={formData.message}
                     onChange={handleChange}
                     required
+                    maxLength={2000}
                     rows={5}
                     placeholder="Tell us more about your inquiry..."
                     className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-af-blue transition-all duration-300 resize-none"

--- a/src/pages/information/AdmissionPage.tsx
+++ b/src/pages/information/AdmissionPage.tsx
@@ -326,6 +326,7 @@ const AdmissionPage: React.FC = () => {
                       value={formData.name}
                       onChange={handleChange}
                       required
+                      maxLength={100}
                       placeholder="Enter student's full name"
                       className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:border-af-blue dark:focus:border-af-light transition-colors"
                     />
@@ -339,6 +340,7 @@ const AdmissionPage: React.FC = () => {
                       value={formData.email}
                       onChange={handleChange}
                       required
+                      maxLength={100}
                       placeholder="your.email@example.com"
                       className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:border-af-blue dark:focus:border-af-light transition-colors"
                     />
@@ -352,6 +354,7 @@ const AdmissionPage: React.FC = () => {
                       value={formData.phone}
                       onChange={handleChange}
                       required
+                      maxLength={100}
                       placeholder="+91-XXXXXXXXXX"
                       className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:border-af-blue dark:focus:border-af-light transition-colors"
                     />
@@ -382,6 +385,7 @@ const AdmissionPage: React.FC = () => {
                     value={formData.guardianName}
                     onChange={handleChange}
                     required
+                    maxLength={100}
                     placeholder="Father's / Mother's name"
                     className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:border-af-blue dark:focus:border-af-light transition-colors"
                   />
@@ -393,6 +397,7 @@ const AdmissionPage: React.FC = () => {
                     name="message"
                     value={formData.message}
                     onChange={handleChange}
+                    maxLength={2000}
                     placeholder="Tell us about your interests, achievements, or any specific questions..."
                     rows={5}
                     className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:border-af-blue dark:focus:border-af-light transition-colors resize-none"


### PR DESCRIPTION
I have implemented `maxLength` constraints on the public-facing forms in `ContactPage.tsx` and `AdmissionPage.tsx`. This is a security enhancement aimed at mitigating potential Denial of Service (DoS) risks by preventing the submission of excessively large amounts of data through these forms. 

Key changes:
- `ContactPage.tsx`: Added `maxLength={100}` to name, email, phone, and subject inputs, and `maxLength={2000}` to the message textarea.
- `AdmissionPage.tsx`: Added `maxLength={100}` to student name, email, phone, and guardian name inputs, and `maxLength={2000}` to the message textarea.

These limits are designed to be generous enough for legitimate use cases while providing a clear boundary for data validation at the client level.

---
*PR created automatically by Jules for task [11146965628690374448](https://jules.google.com/task/11146965628690374448) started by @aryan-357*