### PR TITLE
🔒 Fix Hardcoded API URL Fallback in Alumni Service

### DIFF
--- a/src/services/alumniService.ts
+++ b/src/services/alumniService.ts
@@ -1,12 +1,14 @@
 import { AlumniFormData, AlumniRegistrationResponse } from '../types/alumni';
 import { logErrorSecurely } from '../utils/security';
-import { getFormBackendURL } from '../config';
-
-const API_URL = import.meta.env.VITE_ALUMNI_API_URL || `${getFormBackendURL()}/api/alumni/register`;
 
 export const registerAlumni = async (data: AlumniFormData): Promise<AlumniRegistrationResponse> => {
   try {
-    const response = await fetch(API_URL, {
+    const apiUrl = import.meta.env.VITE_ALUMNI_API_URL;
+    if (!apiUrl) {
+      throw new Error("VITE_ALUMNI_API_URL is not configured.");
+    }
+
+    const response = await fetch(apiUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
🎯 **What:** Removed the hardcoded fallback API URL in `src/services/alumniService.ts`. The code now strictly reads `import.meta.env.VITE_ALUMNI_API_URL` and throws a clear error if it is not configured.
⚠️ **Risk:** If the `VITE_ALUMNI_API_URL` environment variable was accidentally missing or misconfigured, the application would silently fall back to sending potentially sensitive form data to a hardcoded URL (`https://form-backend-afsh-web.up.railway.app/api/alumni/register`). This could lead to unintended data routing and potential security issues if that endpoint is ever deprecated, compromised, or not intended for the current deployment environment.
🛡️ **Solution:** Removed the `API_URL` constant entirely and updated `registerAlumni` to check `import.meta.env.VITE_ALUMNI_API_URL` directly. If the variable is falsy, it throws an error ("VITE_ALUMNI_API_URL is not configured."), allowing the application to fail securely and fast, rather than proceeding with a fallback.

---
*PR created automatically by Jules for task [14214324644184841294](https://jules.google.com/task/14214324644184841294) started by @aryan-357*