### PR TITLE
Fix TypeError and harden components against null CMS props

### DIFF
--- a/src/components/sections/FacultyCarousel.tsx
+++ b/src/components/sections/FacultyCarousel.tsx
@@ -102,8 +102,10 @@ const FacultyCarousel: React.FC<FacultyCarouselProps> = ({
     faculty,
     autoSlideInterval = 5000
 }) => {
+    const displayFaculty = faculty || [];
+
     const [emblaRef, emblaApi] = useEmblaCarousel({
-        loop: true,
+        loop: displayFaculty.length > 0,
         duration: 30,
         align: 'start'
     }, [
@@ -158,7 +160,7 @@ const FacultyCarousel: React.FC<FacultyCarouselProps> = ({
             <div className="container mx-auto px-6">
                 <div className="overflow-hidden" ref={emblaRef}>
                     <div className="flex -ml-6">
-                        {faculty.map((member, index) => (
+                        {displayFaculty.map((member, index) => (
                             <FacultyCard
                                 key={index}
                                 member={member}
@@ -181,7 +183,7 @@ const FacultyCarousel: React.FC<FacultyCarouselProps> = ({
             {/* Dots Pagination */}
             <div className="container mx-auto px-6 relative z-10">
                 <div className="flex justify-center mt-12 gap-3">
-                    {faculty.map((_, idx) => (
+                    {displayFaculty.map((_, idx) => (
                         <button
                             key={idx}
                             onClick={() => emblaApi?.scrollTo(idx)}
@@ -196,7 +198,7 @@ const FacultyCarousel: React.FC<FacultyCarouselProps> = ({
             </div>
 
             {/* Expanded Modal Layer with Transitions */}
-            {openedMemberIndex !== null && (
+            {openedMemberIndex !== null && displayFaculty[openedMemberIndex] && (
                 <div
                     className="fixed inset-0 z-50 flex items-center justify-center p-4 md:p-10 pointer-events-none"
                     onClick={() => setOpenedMemberIndex(null)}
@@ -213,8 +215,8 @@ const FacultyCarousel: React.FC<FacultyCarouselProps> = ({
                     >
                         <div className="w-full md:w-2/5 h-[300px] md:h-auto relative">
                             <img
-                                src={faculty[openedMemberIndex].image}
-                                alt={faculty[openedMemberIndex].name}
+                                src={displayFaculty[openedMemberIndex].image}
+                                alt={displayFaculty[openedMemberIndex].name}
                                 className="w-full h-full object-cover"
                             />
                             <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent md:hidden"></div>

--- a/src/components/sections/PhilosophySection.tsx
+++ b/src/components/sections/PhilosophySection.tsx
@@ -24,9 +24,10 @@ const defaultItems: PhilosophyItem[] = [
 const PhilosophySection: React.FC<PhilosophySectionProps> = ({
     title = 'Fostering Excellence, Integrity, and Service',
     subtitle = 'Our Philosophy',
-    items = defaultItems,
+    items,
     block
 }) => {
+    const displayItems = items || defaultItems;
     return (
         <motion.section
             id="academics"
@@ -50,7 +51,7 @@ const PhilosophySection: React.FC<PhilosophySectionProps> = ({
                     {title}
                 </h2>
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-10 mt-12">
-                    {items.map((item, idx) => (
+                    {displayItems.map((item, idx) => (
                         <motion.div
                             key={idx}
                             whileHover={{ y: -10 }}

--- a/src/components/sections/TopperSection.tsx
+++ b/src/components/sections/TopperSection.tsx
@@ -70,12 +70,15 @@ interface TopperSectionProps {
 }
 
 const TopperSection: React.FC<TopperSectionProps> = ({
-  class12Toppers = defaultToppers12,
-  class10Toppers = defaultToppers10
+  class12Toppers,
+  class10Toppers
 }) => {
   const [activeTab, setActiveTab] = useState<'XII' | 'X'>('X');
 
-  const currentToppers = activeTab === 'XII' ? class12Toppers : class10Toppers;
+  const toppers12 = class12Toppers || defaultToppers12;
+  const toppers10 = class10Toppers || defaultToppers10;
+
+  const currentToppers = activeTab === 'XII' ? toppers12 : toppers10;
 
   const getRankIcon = (position: number) => {
     switch (position) {

--- a/src/components/sections/parallax-carousel/ParallaxCarousel.tsx
+++ b/src/components/sections/parallax-carousel/ParallaxCarousel.tsx
@@ -57,7 +57,8 @@ interface ParallaxCarouselProps {
     slides?: ParallaxSlide[];
 }
 
-const ParallaxCarousel: React.FC<ParallaxCarouselProps> = ({ slides = defaultSlides }) => {
+const ParallaxCarousel: React.FC<ParallaxCarouselProps> = ({ slides }) => {
+    const displaySlides = slides || defaultSlides;
     const [emblaRef, emblaApi] = useEmblaCarousel(OPTIONS);
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [scrollSnaps, setScrollSnaps] = useState<number[]>([]);
@@ -147,7 +148,7 @@ const ParallaxCarousel: React.FC<ParallaxCarouselProps> = ({ slides = defaultSli
         <div className="embla-parallax">
             <div className="embla-parallax__viewport" ref={emblaRef}>
                 <div className="embla-parallax__container">
-                    {slides.map((slide, index) => (
+                    {displaySlides.map((slide, index) => (
                         <div className="embla-parallax__slide" key={slide.id}>
                             <div className="embla-parallax__inner">
                                 <div className="embla-parallax__layer">


### PR DESCRIPTION
This PR fixes a runtime TypeError in the TopperSection component where list properties from TinaCMS could be null, bypassing ES6 default parameter values. The fix involves using explicit logical OR fallbacks within the component body. Similar defensive patterns were proactively applied to PhilosophySection, ParallaxCarousel, and FacultyCarousel to improve overall application resilience against incomplete CMS data. Additionally, FacultyCarousel was hardened with safety checks for modal indexing and Embla Carousel initialization.

---
*PR created automatically by Jules for task [6809656165107492895](https://jules.google.com/task/6809656165107492895) started by @aryan-357*